### PR TITLE
Update the location of the cityhash package.

### DIFF
--- a/hashmap.go
+++ b/hashmap.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 
-	"bitbucket.org/creachadair/cityhash"
+	"github.com/creachadair/cityhash"
 )
 
 type Hashable interface {


### PR DESCRIPTION
This package was rehomed from bitbucket.org to github.com.
The API has otherwise not changed.